### PR TITLE
Fixes for displaying the list clearly on mobiles

### DIFF
--- a/src/css/global.css
+++ b/src/css/global.css
@@ -46,7 +46,18 @@ h2 {
 }
 
 ul {
-  column-count: 2;
+  padding-left: 1em;
+}
+
+@media(min-width:32em){
+  ul {
+    column-count: 2;
+    column-gap: 40px;
+  }
+}
+
+li + li {
+  margin-top: .5em;
 }
 
 footer {


### PR DESCRIPTION
Love the idea of this project, and wanted to contribute as the site didn't display well on mobile...

So I've changed it to a single column on mobiles, list items have a .5em gap between them the make reading the list easier, and on desktop when the list is in two columns there's a column gap for the same reason.

Before:
![companies-that-work-with-ice com_(iPhone 5_SE)](https://user-images.githubusercontent.com/3418339/65408108-4ca5f900-dddc-11e9-8ce1-dc7ff3360309.png)

After:
![localhost_8080_(iPhone 5_SE)](https://user-images.githubusercontent.com/3418339/65408111-4e6fbc80-dddc-11e9-91c8-304316d0e153.png)
