### PR TITLE
Remove GSA

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -40,7 +40,6 @@ You can read more details about these contracts on [Vox Recode](https://www.vox.
 - FCN
 - Four Points Technology
 - FS Vets
-- General Services Administration
 - Govplace
 - Impres Technology Solutions
 - Indev


### PR DESCRIPTION
General Services Administration ( https://www.gsa.gov/ ) is a US government agency, not a company.